### PR TITLE
Reverse order of entries in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+## 0.0.10
+
+- Add feature external app, update version package and update version sdk, VersionStatus now public.
+
+## 0.0.9
+
+- Fix release note, now short description.
+
+## 0.0.8
+
+- Fix remove html response debug
+
+## 0.0.7
+
+- Fix remove unicode character <br>
+
+## 0.0.6
+
+- Add support country code for android with var: androidPlayStoreCountry
+
+## 0.0.5
+
+- Add new parameter in function (showAlertIfNecessary) => LaunchModeVersion -> normal or external
+- Fix: release Note
+
+## 0.0.4
+
+- fixed Error resolving dependencies after updating package_info_plus to 2.0.0 by [Polevshchikov](https://github.com/Polevshchikov)
+- fixed get version app, now with regexpr by [mauriziopinotti](https://github.com/mauriziopinotti)
+- modified regexpr now Supports 1.2.3 (most of the apps), 1.1.3-rc-06, 1.17 and 1.2.prod.3 (e.g. Google Cloud)
+
+## 0.0.3
+
+- fixed URL open in web view inside the app
+- modified file readme
+
+## 0.0.2
+
+- Support last version of flutter
+- Update plugin :)
+- version stable
+
+## 0.0.1+4
+
+- Support old version flutter 2.5.0 it remove version 0.0.2
+
+## 0.0.1+3
+
+- Support old version flutter 2.5.0 it remove version 0.0.2
+
+## 0.0.1+2
+
+- Support old version flutter 2.5.0 it remove version 0.0.2
+
+## 0.0.1+1
+
+- Fix pub dev
+
+#### Version Migrate
+
+- Update plugin
+
 ## 0.0.1
 
 #### Version oiginal:
@@ -21,65 +83,3 @@
 - Add more granular parameters, fix Android web view and navigation bugs.
 - Fix HTTPS bug on iOS. Fix null return for android version statuses. Upgrade dependencies.
 - Initial release. API includes `getVersionStatus` and `showAlertIfNecessary` methods. Support for iOS and Android.
-
-#### Version Migrate
-
-- Update plugin
-
-## 0.0.1+1
-
-- Fix pub dev
-
-## 0.0.1+2
-
-- Support old version flutter 2.5.0 it remove version 0.0.2
-
-## 0.0.1+3
-
-- Support old version flutter 2.5.0 it remove version 0.0.2
-
-## 0.0.1+4
-
-- Support old version flutter 2.5.0 it remove version 0.0.2
-
-## 0.0.2
-
-- Support last version of flutter
-- Update plugin :)
-- version stable
-
-## 0.0.3
-
-- fixed URL open in web view inside the app
-- modified file readme
-
-## 0.0.4
-
-- fixed Error resolving dependencies after updating package_info_plus to 2.0.0 by [Polevshchikov](https://github.com/Polevshchikov)
-- fixed get version app, now with regexpr by [mauriziopinotti](https://github.com/mauriziopinotti)
-- modified regexpr now Supports 1.2.3 (most of the apps), 1.1.3-rc-06, 1.17 and 1.2.prod.3 (e.g. Google Cloud)
-
-## 0.0.5
-
-- Add new parameter in function (showAlertIfNecessary) => LaunchModeVersion -> normal or external
-- Fix: release Note
-
-## 0.0.6
-
-- Add support country code for android with var: androidPlayStoreCountry
-
-## 0.0.7
-
-- Fix remove unicode character <br>
-
-## 0.0.8
-
-- Fix remove html response debug
-
-## 0.0.9
-
-- Fix release note, now short description.
-
-## 0.0.10
-
-- Add feature external app, update version package and update version sdk, VersionStatus now public.


### PR DESCRIPTION
The common practice is to order entries in the changelog in descending order so that the most recent changes appear at the top. When a new major release is coming out and you need to check it for breaking changes, it is much easier to open the changelog and see it immediately, rather than scrolling all the way down.