### PR TITLE
fix : sometimes cant get data from appstore when use bundleId

### DIFF
--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -154,7 +154,14 @@ class NewVersionPlus {
   /// JSON document.
   Future<VersionStatus?> _getiOSStoreVersion(PackageInfo packageInfo) async {
     final id = iOSId ?? packageInfo.packageName;
-    final parameters = {"bundleId": id};
+    
+    Map<String, dynamic> parameters = {};
+    if(id.contains('.')){
+      parameters['bundleId'] = id;
+    }else{
+      parameters['id']= id;
+    }
+    
     if (iOSAppStoreCountry != null) {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }


### PR DESCRIPTION
I got some error when i using bundleId as parameter to get data from AppStore, it happens after i hide the app from AppStore. After i published it again, the lib or the URL cant return the data anymore, but when use appId its returning data.

So in this PR, i add capability to set iosId set using bundle ID or app ID.

so if before only able to set this 

`final newVersion = NewVersionPlus(iosId : "com.bundle.id")`

now able to set like this too :
`final newVersion = NewVersionPlus(iosId : "123456789")` 

hopefully it can solve this [issue](https://github.com/CodesFirst/new_version_plus/issues/34) too.

Regards