### PR TITLE
Add timestamp parameter to itunes lookup request

### DIFF
--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -154,7 +154,8 @@ class NewVersionPlus {
   /// JSON document.
   Future<VersionStatus?> _getiOSStoreVersion(PackageInfo packageInfo) async {
     final id = iOSId ?? packageInfo.packageName;
-    final parameters = {"bundleId": id};
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final parameters = {"bundleId": id, "t": timestamp.toString()};
     if (iOSAppStoreCountry != null) {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }


### PR DESCRIPTION
Sometimes Apple's response from lookup is outdated due to some cache header. Some responses have to wait up to 24 hours to update the value
By passing the timestamp to the request should bypass the cache