### PR TITLE
Bug Fix (#43) Surround http get calls with try catch blocks

### DIFF
--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -162,7 +162,7 @@ class NewVersionPlus {
     try {
       final response = await http.get(uri);
     } catch (e) {
-      debugPrint('Failed to query iOS App Store');
+      debugPrint('Failed to query iOS App Store', e.toString());
     }
     if (response.statusCode != 200) {
       debugPrint('Failed to query iOS App Store');
@@ -193,7 +193,7 @@ class NewVersionPlus {
     try {
       final response = await http.get(uri);
     } catch (e) {
-      debugPrint('Failed to query Google Play Store');
+      debugPrint('Failed to query Google Play Store', e.toString());
     }
     if (response.statusCode != 200) {
       throw Exception("Invalid response code: ${response.statusCode}");

--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -159,7 +159,11 @@ class NewVersionPlus {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }
     var uri = Uri.https("itunes.apple.com", "/lookup", parameters);
-    final response = await http.get(uri);
+    try {
+      final response = await http.get(uri);
+    } catch (e) {
+      debugPrint('Failed to query iOS App Store');
+    }
     if (response.statusCode != 200) {
       debugPrint('Failed to query iOS App Store');
       return null;
@@ -186,7 +190,11 @@ class NewVersionPlus {
     final id = androidId ?? packageInfo.packageName;
     final uri = Uri.https("play.google.com", "/store/apps/details",
         {"id": id.toString(), "hl": androidPlayStoreCountry ?? "en_US"});
-    final response = await http.get(uri);
+    try {
+      final response = await http.get(uri);
+    } catch (e) {
+      debugPrint('Failed to query Google Play Store');
+    }
     if (response.statusCode != 200) {
       throw Exception("Invalid response code: ${response.statusCode}");
     }

--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -159,10 +159,12 @@ class NewVersionPlus {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }
     var uri = Uri.https("itunes.apple.com", "/lookup", parameters);
+    var response;
     try {
-      final response = await http.get(uri);
+      response = await http.get(uri);
     } catch (e) {
-      debugPrint('Failed to query iOS App Store', e.toString());
+      debugPrint('Failed to query iOS App Store\n' + e.toString());
+      return null;
     }
     if (response.statusCode != 200) {
       debugPrint('Failed to query iOS App Store');
@@ -190,10 +192,12 @@ class NewVersionPlus {
     final id = androidId ?? packageInfo.packageName;
     final uri = Uri.https("play.google.com", "/store/apps/details",
         {"id": id.toString(), "hl": androidPlayStoreCountry ?? "en_US"});
+    var response;
     try {
-      final response = await http.get(uri);
+      response = await http.get(uri);
     } catch (e) {
-      debugPrint('Failed to query Google Play Store', e.toString());
+      debugPrint('Failed to query Google Play Store\n' + e.toString());
+      return null;
     }
     if (response.statusCode != 200) {
       throw Exception("Invalid response code: ${response.statusCode}");


### PR DESCRIPTION
This PR fixes #43 which happens due to not handling the http.get() exceptions. This PR surrounds the http get calls with try catch blocks.