### PR TITLE
feat: add "timestamp" in HTTP queries to prevent cache issues, primar…

### DIFF
--- a/lib/new_version_plus.dart
+++ b/lib/new_version_plus.dart
@@ -154,7 +154,10 @@ class NewVersionPlus {
   /// JSON document.
   Future<VersionStatus?> _getiOSStoreVersion(PackageInfo packageInfo) async {
     final id = iOSId ?? packageInfo.packageName;
-    final parameters = {"bundleId": id};
+    final parameters = {
+      "bundleId": id,
+      "timestamp": DateTime.now().millisecondsSinceEpoch.toString()
+    };
     if (iOSAppStoreCountry != null) {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }
@@ -185,7 +188,11 @@ class NewVersionPlus {
       PackageInfo packageInfo) async {
     final id = androidId ?? packageInfo.packageName;
     final uri = Uri.https("play.google.com", "/store/apps/details",
-        {"id": id.toString(), "hl": androidPlayStoreCountry ?? "en_US"});
+        {"id": id.toString(), 
+        "hl": androidPlayStoreCountry ?? "en_US",
+        "timestamp": DateTime.now().millisecondsSinceEpoch.toString()
+        }
+      );
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       throw Exception("Invalid response code: ${response.statusCode}");


### PR DESCRIPTION
This pull request addresses cache issues encountered primarily on iOS devices when making HTTP queries. 
The issue arises from discrepancies in the version returned by the iTunes lookup API, leading to outdated information being cached. To mitigate this problem, I've added a timestamp parameter to the HTTP queries, ensuring that the latest version information is always retrieved. 

[StackOverflow example](https://stackoverflow.com/questions/43226752/itunes-lookup-api-return-old-data-in-my-app)
This change resolves a similar issue where the iTunes lookup API returned an old version (4.8.1) despite a new version (4.9) being available when accessed through a browser. With this fix, the app will now consistently retrieve and display the correct version information, improving user experience and ensuring accurate update checks.
